### PR TITLE
Prevent PHP notice when creating a symlink without a new directory

### DIFF
--- a/includes/lib/class-easy-symlinks-functions.php
+++ b/includes/lib/class-easy-symlinks-functions.php
@@ -204,6 +204,7 @@ class Easy_Symlinks_Functions {
 	 */
 	public function create_folder( $target ) {
 		$homepath = $this->get_wp_homepath();
+		$status = FALSE;
 
 		// Get the target folder name.
 		if ( preg_match( '/\/uploads\/\W?\K.*/', $target, $matches ) ) {


### PR DESCRIPTION
If you create a symlink that does not also create a new directory, you'll get this PHP notice:

`Notice: Undefined variable: status in /code/wp-content/plugins/easy-symlinks/includes/lib/class-easy-symlinks-functions.php on line 213`

We need to set a value for `$status` in case the `mkdir` never happens.