### PR TITLE
Adds cleanup steps when uninstalling the plugin

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -3,16 +3,18 @@ name: Run PHPCS on pull requests
 on: pull_request
 
 jobs:
-  phpcs:
-
+  runPHPCSInspection:
+    name: Run PHPCS inspection
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v2
       with:
-         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: docker://rtcamp/action-phpcs-code-review:v2.0.0
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Run PHPCS inspection
+      uses: rtCamp/action-phpcs-code-review@v2.0.3
       env:
         GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        SKIP_FOLDERS: "tests,.github"
+        PHPCS_SNIFFS_EXCLUDE: "WordPress.Files.FileName"
       with:
         args: "WordPress,WordPress-Core,WordPress-Docs"

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,3 +8,22 @@
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
+
+// loading up to get the home path
+require_once ABSPATH . 'wp-admin/includes/file.php';
+// load the easy-symlinks file so we can later get token and version
+include_once 'easy-symlinks.php';
+
+// unlink paths
+$links = maybe_unserialize( get_option( 'caes_symlink_list' ) );
+foreach ($links as $key => $value) {
+	$link = strstr( $value, ' ->', true );
+	unlink( get_home_path() . $link );
+}
+
+// remove options
+delete_option( easy_symlinks()->token . 'version', easy_symlinks()->version );
+delete_option( 'caes_symlink_list' );
+delete_option( 'caes_symlink_list_lastdelete' );
+delete_option( 'caes_target' );
+delete_option( 'caes_link' );


### PR DESCRIPTION
When uninstalling from the dashboard the plugin will now remove the
symlinks created as well as the options from the database.

fixes: #33