### PR TITLE
Add capability to detect the environment

### DIFF
--- a/includes/class-easy-symlinks-settings.php
+++ b/includes/class-easy-symlinks-settings.php
@@ -311,6 +311,76 @@ class Easy_Symlinks_Settings {
 	}
 
 	/**
+	 * Render the environment info banner.
+	 *
+	 * @param array $env Environment data from detect_environment().
+	 * @return string HTML for the banner.
+	 */
+	private function render_environment_banner( $env ) {
+		$is_pantheon = ( 'pantheon' === $env['type'] );
+		$readonly    = $is_pantheon && in_array( $env['environment'], array( 'test', 'live' ), true );
+
+		if ( $readonly ) {
+			$notice_class = 'notice-error';
+			$status_label = 'Read-only';
+			$dashicon     = 'dashicons-lock';
+		} elseif ( $env['writable'] ) {
+			$notice_class = 'notice-success';
+			$status_label = 'Writable';
+			$dashicon     = 'dashicons-unlock';
+		} else {
+			$notice_class = 'notice-warning';
+			$status_label = 'Not writable';
+			$dashicon     = 'dashicons-warning';
+		}
+
+		$html  = '<div class="notice ' . $notice_class . '" style="padding:12px 16px;margin:15px 0;">';
+		$html .= '<p style="margin:0 0 6px;font-size:14px;font-weight:600;">';
+		$html .= '<span class="dashicons ' . $dashicon . '" style="margin-right:6px;vertical-align:text-bottom;"></span>';
+		$html .= 'Environment: ' . esc_html( $env['label'] );
+		$html .= '</p>';
+
+		$html .= '<table style="border-collapse:collapse;margin:0;">';
+
+		$html .= '<tr><td style="padding:2px 12px 2px 0;font-weight:500;">Type</td>';
+		$html .= '<td style="padding:2px 0;">' . esc_html( $is_pantheon ? 'Pantheon' : 'Local / Non-Pantheon' ) . '</td></tr>';
+
+		if ( $is_pantheon ) {
+			$html .= '<tr><td style="padding:2px 12px 2px 0;font-weight:500;">Environment</td>';
+			$html .= '<td style="padding:2px 0;">' . esc_html( $env['environment'] ) . '</td></tr>';
+
+			if ( ! empty( $env['site_name'] ) ) {
+				$html .= '<tr><td style="padding:2px 12px 2px 0;font-weight:500;">Site Name</td>';
+				$html .= '<td style="padding:2px 0;">' . esc_html( $env['site_name'] ) . '</td></tr>';
+			}
+
+			if ( ! empty( $env['connection'] ) ) {
+				$html .= '<tr><td style="padding:2px 12px 2px 0;font-weight:500;">Connection Mode</td>';
+				$html .= '<td style="padding:2px 0;">' . esc_html( strtoupper( $env['connection'] ) ) . '</td></tr>';
+			}
+		}
+
+		$html .= '<tr><td style="padding:2px 12px 2px 0;font-weight:500;">Filesystem</td>';
+		$html .= '<td style="padding:2px 0;">' . esc_html( $status_label ) . '</td></tr>';
+
+		$html .= '</table>';
+
+		if ( $readonly ) {
+			$html .= '<p style="margin:8px 0 0;"><strong>Symlinks cannot be created in read-only environments.</strong> Switch to a Dev or Multidev environment.</p>';
+		} elseif ( ! $env['writable'] ) {
+			if ( $is_pantheon ) {
+				$html .= '<p style="margin:8px 0 0;">Filesystem is not writable. Switch to <strong>SFTP mode</strong> in the Pantheon dashboard.</p>';
+			} else {
+				$html .= '<p style="margin:8px 0 0;">Filesystem is not writable. Check your file permissions.</p>';
+			}
+		}
+
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
 	 * Load settings page content.
 	 *
 	 * @return void
@@ -318,13 +388,25 @@ class Easy_Symlinks_Settings {
 	public function settings_page() {
 
 		$links = new Easy_Symlinks_Functions();
+		$env   = $links->detect_environment();
+
+		$sanitisation = new Easy_Symlinks_Admin_API();
+		$writestatus  = $links->check_if_in_pantheon_writable_env();
+
+		// Always render the page wrapper, heading, and environment banner.
+		echo '<div class="wrap" id="' . esc_html( $this->parent->token ) . '_settings">' . "\n";
+		echo '<h2>' . esc_html( __( 'Easy Symlinks Management', 'easy-symlinks' ) ) . '</h2>' . "\n";
+		echo wp_kses( $this->render_environment_banner( $env ), $sanitisation->allowed_htmls );
+
+		if ( ! $writestatus['status'] ) {
+			echo '</div>';
+			return;
+		}
 
 		// Build page HTML.
-		$nonce     = sanitize_text_field( wp_create_nonce( 'caes_nonce' ) );
-		$html      = '<div class="wrap" id="' . $this->parent->token . '_settings">' . "\n";
-			$html .= '<h2>' . __( 'Easy Symlinks Management', 'easy-symlinks' ) . '</h2>' . "\n";
-
-			$tab = '';
+		$nonce = sanitize_text_field( wp_create_nonce( 'caes_nonce' ) );
+		$html  = '';
+		$tab   = '';
 
 		// Proper nonce handling.
 		if ( isset( $_GET['caes_nonce'] ) ) {
@@ -371,7 +453,6 @@ class Easy_Symlinks_Settings {
 					array(
 						'tab'        => $section,
 						'caes_nonce' => $nonce,
-						// add nonce validation here.
 					)
 				);
 
@@ -406,18 +487,7 @@ class Easy_Symlinks_Settings {
 			$html         .= '</form>' . "\n";
 		$html             .= '</div>' . "\n";
 
-		$sanitisation = new Easy_Symlinks_Admin_API();
-		$writable     = new Easy_Symlinks_Functions();
-		$writestatus  = $writable->check_if_in_pantheon_writable_env();
-
-		if ( $writestatus['status'] ) {
-			echo wp_kses( $html, $sanitisation->allowed_htmls );
-		} else {
-			echo '<div class="wrap" id="' . esc_html( $this->parent->token ) . '_settings">' . "\n";
-			echo '<h2>' . esc_html( __( 'Easy Symlinks Management', 'easy-symlinks' ) ) . '</h2>' . "\n";
-			echo '<div class="notice notice-error settings-error">' . esc_html( $writestatus['error'] ) . '</div>';
-			echo '</div>';
-		}
+		echo wp_kses( $html, $sanitisation->allowed_htmls );
 	}
 
 	/**

--- a/includes/lib/class-easy-symlinks-admin-api.php
+++ b/includes/lib/class-easy-symlinks-admin-api.php
@@ -269,12 +269,14 @@ class Easy_Symlinks_Admin_API {
 		'span'   => [
 			'class' => [],
 			'title' => [],
+			'style' => [],
 		],
 		'table'  => [
 			'scope' => [],
 			'title' => [],
 			'class' => [],
 			'role'  => [],
+			'style' => [],
 		],
 		'tbody'  => [
 			'scope' => [],
@@ -286,9 +288,15 @@ class Easy_Symlinks_Admin_API {
 			'scope' => [],
 			'title' => [],
 		],
-		'tr'     => [],
-		'td'     => [],
-		'p'      => [],
+		'tr'     => [
+			'style' => [],
+		],
+		'td'     => [
+			'style' => [],
+		],
+		'p'      => [
+			'style' => [],
+		],
 		'br'     => [],
 		'em'     => [],
 		'strong' => [],
@@ -307,6 +315,7 @@ class Easy_Symlinks_Admin_API {
 		'div'    => [
 			'class' => [],
 			'id'    => [],
+			'style' => [],
 		],
 	];
 }

--- a/includes/lib/class-easy-symlinks-functions.php
+++ b/includes/lib/class-easy-symlinks-functions.php
@@ -159,19 +159,64 @@ class Easy_Symlinks_Functions {
 	}
 
 	/**
+	 * Detect the current hosting environment.
+	 *
+	 * @return array {
+	 *     @type string $type        'pantheon' or 'local'.
+	 *     @type string $environment Pantheon environment name or 'local'.
+	 *     @type string $label       Human-readable environment label.
+	 *     @type bool   $writable    Whether the filesystem is writable.
+	 *     @type string $site_name   Pantheon site name if available.
+	 *     @type string $connection  Pantheon connection mode (sftp/git) if detectable.
+	 * }
+	 */
+	public function detect_environment() {
+		$env = array(
+			'type'        => 'local',
+			'environment' => 'local',
+			'label'       => 'Local Development',
+			'writable'    => $this->check_fs_writable(),
+			'site_name'   => '',
+			'connection'  => '',
+		);
+
+		if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+			$env['type']        = 'pantheon';
+			$env['environment'] = sanitize_text_field( $_ENV['PANTHEON_ENVIRONMENT'] );
+			$env['site_name']   = isset( $_ENV['PANTHEON_SITE_NAME'] ) ? sanitize_text_field( $_ENV['PANTHEON_SITE_NAME'] ) : '';
+
+			$labels = array(
+				'dev'  => 'Pantheon Dev',
+				'test' => 'Pantheon Test',
+				'live' => 'Pantheon Live',
+			);
+			$env['label'] = isset( $labels[ $env['environment'] ] )
+				? $labels[ $env['environment'] ]
+				: 'Pantheon Multidev (' . $env['environment'] . ')';
+
+			if ( isset( $_ENV['PANTHEON_ENVIRONMENT_CONNECTION_MODE'] ) ) {
+				$env['connection'] = sanitize_text_field( $_ENV['PANTHEON_ENVIRONMENT_CONNECTION_MODE'] );
+			}
+		}
+
+		return $env;
+	}
+
+	/**
 	 * Check if writable filesystem.
 	 *
 	 * @return array
 	 */
 	public function check_if_in_pantheon_writable_env() {
-		if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
-			if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ), true ) ) {
+		$env = $this->detect_environment();
+
+		if ( 'pantheon' === $env['type'] ) {
+			if ( in_array( $env['environment'], array( 'test', 'live' ), true ) ) {
 				$return['error']  = 'This plugin can not be used in Test and Live Read-only Environments in Pantheon';
 				$return['status'] = false;
 				return $return;
 			} else {
-				$writable = $this->check_fs_writable();
-				if ( $writable ) {
+				if ( $env['writable'] ) {
 					$return['error']  = 'In Writable Environment';
 					$return['status'] = true;
 					return $return;
@@ -182,8 +227,7 @@ class Easy_Symlinks_Functions {
 				}
 			}
 		} else {
-			$writable = $this->check_fs_writable();
-			if ( $writable ) {
+			if ( $env['writable'] ) {
 				$return['error']  = 'In Writable filesystem';
 				$return['status'] = true;
 				return $return;


### PR DESCRIPTION
## Summary

- Add environment detection (Pantheon Dev/Test/Live/Multidev and local) with status banner
- Modernize admin UI with card-based layout, pill-style tabs, full-width inputs, and red delete button
- Fix duplicate admin notices on settings save
- Fix PHP warning in `create_folder()` when directory already exists
- Fix PHPCS violations — plugin now passes WordPress coding standards (0 errors)
- Add success/error notifications for symlink deletion
- Add WordPress.org submission assets (banners, icons, screenshots) with deploy workflow
- Update deploy workflow to use `actions/checkout@v4`, `10up/action-wordpress-plugin-deploy@stable`, and auto-upload assets
- Version bump to 1.0.4, tested up to WP 6.8 / PHP 8.4
- Add `Requires PHP: 7.4` header
- Expand `readme.txt` with FAQ, screenshots, upgrade notices

## Test plan

- [x] Activate plugin on WordPress 6.8 / PHP 8.4
- [x] Visit Settings > Easy Symlinks — verify card layout, pill tabs, environment banner
- [x] Add a symlink — verify no duplicate notices, form works
- [x] Delete a symlink — verify success/error notification appears
- [x] Verify in read-only environment (Pantheon Test/Live) the UI is disabled
- [x] Run `phpcs` — should return 0 errors
- [x] Tag `1.0.4` and verify deploy workflow triggers

